### PR TITLE
Limit Meetup RSVPs

### DIFF
--- a/src/plugins/Meetup/__init__.py
+++ b/src/plugins/Meetup/__init__.py
@@ -31,6 +31,9 @@ class MeetupPlugin(Plugin):
 			},{
 				'name': 'Title append',
 				'type': 'text',
+			},{
+				'name': 'Allow RSVP',
+				'type': 'yesno',
 			}
 		]
 		#@TODO: Allow option for publishing meetup events immediately
@@ -58,6 +61,9 @@ class MeetupPlugin(Plugin):
 			
 		if append != '':
 			title += ' ' + append
+		rsvp_limit = 1;
+		if config.checkBool(self.getSetting("Allow RSVP")):
+			rsvp_limit=0
 		
 		self.checkForInterruption()
 		meetupEvent = api.CreateEvent({
@@ -68,6 +74,7 @@ class MeetupPlugin(Plugin):
 			'duration': event['startTime'].msecsTo(event['stopTime']),
 			'venue_id': self.getSetting('Venue ID'),
 			'publish_status': 'draft',
+			'rsvp_limit': rsvp_limit
 		})
 		
 		if config.checkBool(self.getSetting('Use this as registration URL')):


### PR DESCRIPTION
This creates an option in the Meetup plugin to "Disable" RSVPS by limiting it to 1 person (Dom).  I tested that the code runs without error and creates the config option, but I don't have the config file or access to the Meetup group, so I can't test.

 Relevant API call:
> rsvp_limit – Total number of RSVPs available for the event. To remove this limit, set this to 0